### PR TITLE
Remove single quotes from parameter values on windows

### DIFF
--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -7,7 +7,7 @@ MSON = require 'mongoson'
 
 module.exports = utils = {}
 utils.log = ->
-  
+
 utils.loggedExec = (command, next) ->
   utils.log "> #{command}"
   exec command, next
@@ -44,7 +44,7 @@ utils.restoreDatabase = (connectionString, dirName, next) ->
     return next null, stdOut, stdErr
 
 utils.makeDumpCommand = (connectionString, dirName) ->
-  throw "No target directory given." unless dirName 
+  throw "No target directory given." unless dirName
   throw "Target directory must be a string" unless typeof dirName is "string"
   connectionParameters = utils.parseConnectionString connectionString
   commandOptions = makeCommandOptions connectionParameters
@@ -54,7 +54,7 @@ utils.makeDumpCommand = (connectionString, dirName) ->
   "mongodump#{argumentString}"
 
 utils.makeRestoreCommand = (connectionString, dirName) ->
-  throw "No source directory given." unless dirName 
+  throw "No source directory given." unless dirName
   throw "Source directory must be a string" unless typeof dirName is "string"
   actualDirName = utils.findDumpDirName dirName
   utils.log "Using #{actualDirName}"
@@ -69,13 +69,13 @@ utils.findDumpDirName = (dirName) ->
   dirCount = 0
   for entryName in fs.readdirSync dirName
     if fs.statSync("#{dirName}/#{entryName}").isDirectory()
-      dirCount += 1 
+      dirCount += 1
       lastDirName = entryName
   switch dirCount
     when 0 then return dirName # a proper dump dir
     when 1 then return dirName + "/" + lastDirName # assume this one is proper
     else throw new Error "#{dirName} contains multiple directories."
-  
+
 utils.dumpHerokuMongoHQDatabase = (appName, dirName, next) ->
   utils.findHerokuMongoHQURL appName, (err, url) ->
     utils.log "Using #{url}"
@@ -111,9 +111,9 @@ makeCommandOptions = (connParams) ->
   options.password = connParams.password if connParams.password
   options
 
-makeCommandArguments = (options, object) ->  
+makeCommandArguments = (options, object) ->
   args = []
-  for name, value of options 
+  for name, value of options
     args.push "--#{name}" unless value is false
     args.push "#{value}" unless value is true or value is false
   args.push object if object
@@ -121,5 +121,9 @@ makeCommandArguments = (options, object) ->
 
 makeArgumentString = (args) ->
   str = ""
-  str += " '#{arg}'" for arg in args
+  for arg in args
+    if process.platform is 'win32'
+      str += " #{arg}"
+    else
+      str += " '#{arg}'"
   str


### PR DESCRIPTION
This change fixes issues #4 and #7. This only applies to Windows hosts where parameters are specified slightly differently.

Apologies about the line endings - L124-128 were the only real changes.